### PR TITLE
.github: Add issue, PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!-- The following items are listed to help you get your issue resolved quickly -->
+## Checklist
+- [ ] I am running the latest version. Installing Isso from GitHub from the `master` branch does not fix my issue
+- [ ] I have checked the [troubleshooting guide](https://posativ.org/isso/docs/troubleshooting/)
+- [ ] I have searched the [open issues](https://github.com/posativ/isso/issues), but my issue has not already been reported
+
+## What is not working?
+<!-- Explain your issue in detail -->
+...
+
+## How can one reproduce this issue?
+<!-- Post your isso.cfg, other relevant configuration/setup -->
+...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Just like NASA going to the moon, it's always good to have a checklist when
+creating changes.
+The following items are listed to help you create a great Pull Request: -->
+## Checklist
+- [ ] All new and existing **tests are passing**
+- [ ] (If adding features:) I have added tests to cover my changes
+- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
+- [ ] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
+- [ ] I have written **proper commit message(s)**
+      <!-- Title ideally under 50 characters (at most 72), good explanations,
+      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
+      Further info: https://github.com/joelparkerhenderson/git-commit-message -->
+
+## What changes does this Pull Request introduce?
+<!-- Explain what this PR will do, how one can try out the changes -->
+...
+
+## Why is this necessary?
+<!-- Link to existing bugs, post reproducible setups that demonstrate the
+     issue/change -->
+...


### PR DESCRIPTION
Encourage users to fill out some basic information and guide their thought processes.

As opposed to https://github.com/posativ/isso/pull/753, these templates are much less intrusive/inquisitive and merely guide the user instead of demanding excessive amounts of information.

Reasoning: While reviewing PRs of more or less new contributors to the project such as @BBaoVanC and @fliiiix, I had to coax their PRs metadata into a more reviewable shape. BBaoVanC even ended up writing checklists for themself. Formalizing this process a bit makes sense, IMO.

@jelmer thoughts?