### PR TITLE
comments: Fix total comments count calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Bugfixes & Improvements
 - Prevent auto creation of invalid links in comments (`#995`_, pkvach)
 - Fix W3C Validation issues (`#999`_, pkvach)
 - Handle deleted comments in Disqus migration (`#994`_, pkvach)
+- Fix total comments count calculation (`#997`_, pkvach)
 
 .. _#951: https://github.com/posativ/isso/pull/951
 .. _#967: https://github.com/posativ/isso/pull/967
@@ -34,6 +35,7 @@ Bugfixes & Improvements
 .. _#995: https://github.com/isso-comments/isso/pull/995
 .. _#999: https://github.com/isso-comments/isso/pull/999
 .. _#994: https://github.com/isso-comments/isso/pull/994
+.. _#997: https://github.com/isso-comments/isso/pull/997
 
 0.13.1.dev0 (2023-02-05)
 ------------------------

--- a/isso/js/embed.js
+++ b/isso/js/embed.js
@@ -139,7 +139,6 @@ function fetchComments() {
                 if (comment.created > lastcreated) {
                     lastcreated = comment.created;
                 }
-                count = count + comment.total_replies;
             });
             heading.textContent = i18n.pluralize("num-comments", count);
 

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -100,6 +100,7 @@ class TestComments(unittest.TestCase):
 
         rv = loads(r.data)
         self.assertEqual(len(rv['replies']), 20)
+        self.assertEqual(rv['total_replies'], 20)
 
     def testCreateInvalidParent(self):
 
@@ -185,15 +186,18 @@ class TestComments(unittest.TestCase):
         self.assertEqual(self.get('/?uri=%2Fpath%2F&id=123').status_code, 200)
         data = loads(self.get('/?uri=%2Fpath%2F&id=123').data)
         self.assertEqual(len(data['replies']), 0)
+        self.assertEqual(data['total_replies'], 0)
 
         self.assertEqual(
             self.get('/?uri=%2Fpath%2Fspam%2F&id=123').status_code, 200)
         data = loads(self.get('/?uri=%2Fpath%2Fspam%2F&id=123').data)
         self.assertEqual(len(data['replies']), 0)
+        self.assertEqual(data['total_replies'], 0)
 
         self.assertEqual(self.get('/?uri=?uri=%foo%2F').status_code, 200)
         data = loads(self.get('/?uri=?uri=%foo%2F').data)
         self.assertEqual(len(data['replies']), 0)
+        self.assertEqual(data['total_replies'], 0)
 
     def testFetchEmpty(self):
 
@@ -214,6 +218,7 @@ class TestComments(unittest.TestCase):
 
         rv = loads(r.data)
         self.assertEqual(len(rv['replies']), 10)
+        self.assertEqual(rv['total_replies'], 20)
 
     def testGetNested(self):
 
@@ -226,6 +231,7 @@ class TestComments(unittest.TestCase):
 
         rv = loads(r.data)
         self.assertEqual(len(rv['replies']), 1)
+        self.assertEqual(rv['total_replies'], 1)
 
     def testGetLimitedNested(self):
 
@@ -239,6 +245,7 @@ class TestComments(unittest.TestCase):
 
         rv = loads(r.data)
         self.assertEqual(len(rv['replies']), 10)
+        self.assertEqual(rv['total_replies'], 20)
 
     def testUpdate(self):
 
@@ -289,7 +296,7 @@ class TestComments(unittest.TestCase):
         self.assertIn('/path/', self.app.db.threads)
 
         data = loads(client.get("/?uri=%2Fpath%2F").data)
-        self.assertEqual(data["total_replies"], 1)
+        self.assertEqual(data["total_replies"], 2)
 
         self.assertEqual(self.get('/?uri=%2Fpath%2F&id=1').status_code, 200)
         self.assertEqual(self.get('/?uri=%2Fpath%2F&id=2').status_code, 200)

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -880,6 +880,9 @@ class API(object):
         if root_id not in reply_counts:
             reply_counts[root_id] = 0
 
+        # We need to calculate the total number of comments for the root response value
+        total_replies = sum(reply_counts.values()) if root_id is None else reply_counts[root_id]
+
         try:
             nested_limit = int(request.args.get('nested_limit'))
         except TypeError:
@@ -889,7 +892,7 @@ class API(object):
 
         rv = {
             'id': root_id,
-            'total_replies': reply_counts[root_id],
+            'total_replies': total_replies,
             'hidden_replies': reply_counts[root_id] - len(root_list),
             'replies': self._process_fetched_list(root_list, plain),
             'config': self.public_conf


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x]  I have added an entry to CHANGES.rst because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
Changes to properly count hidden comments when calculating the total number of comments.

- `isso/views/comments.py`: The calculation of total_replies is modified. Instead of directly assigning the value of reply_counts[root_id] to total_replies, it now calculates the sum of all values in reply_counts if root_id is None, otherwise it assigns the value of reply_counts[root_id].

- `isso/js/embed.js`: The redundant incrementation of the count variable with comment.total_replies was removed.

- `isso/tests/test_comments.py`: Several assertions are added to various test cases to check the value of total_replies in the response data.

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
Fixes https://github.com/isso-comments/isso/issues/448

### Demo
- Before fix

![image](https://github.com/isso-comments/isso/assets/5307506/28f14f70-ec45-4963-840e-5c393c51c4c2)

- After fix

![image](https://github.com/isso-comments/isso/assets/5307506/8feeb46e-9b5a-444d-b045-9a22e5675efd)
