### PR TITLE
Python 3.12 compatibility; docker, venv/virtualenv

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         # Use only lowest and highest supported python versions for now,
         # to speed up CI runs
-        python-version: [3.8, "3.11"]
+        python-version: [3.8, "3.12"]
         node-version: [16]
       fail-fast: false
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Generate Isso package
       id: generate-package
       run: |
+        pip install setuptools
         python setup.py sdist
         echo "::set-output name=package_file::$(ls dist/)"
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Bugfixes & Improvements
 - Add link logging for management of new comments in Stdout (`#1016`_, pkvach)
 - Change logging to include datetime and loglevel (`#1023`_, ix5)
 - Make 'text' field in 'comments' table NOT NULL and handling data migration (`#1019`_, pkvach)
+- Python 3.12 support (`#1015`_, ix5)
 
 .. _#951: https://github.com/posativ/isso/pull/951
 .. _#967: https://github.com/posativ/isso/pull/967
@@ -58,6 +59,7 @@ Bugfixes & Improvements
 .. _#1016: https://github.com/isso-comments/isso/pull/1016
 .. _#1023: https://github.com/isso-comments/isso/pull/1023
 .. _#1019: https://github.com/isso-comments/isso/pull/1019
+.. _#1015: https://github.com/isso-comments/isso/pull/1015
 
 0.13.1.dev0 (2023-02-05)
 ------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN virtualenv --download /isso \
 COPY ["setup.py", "setup.cfg", "README.md", "LICENSE", "./"]
 RUN --mount=type=cache,target=/root/.cache \
   . /isso/bin/activate \
- && python3 setup.py develop
+ && pip install -e .
 
 # Then copy over files
 # SRC "isso/" is treated as "isso/*" by docker, so copy to subdir explicitly
@@ -69,7 +69,7 @@ COPY --from=isso-js /src/isso/js/ ./isso/js
 # Build and install Isso package (pip dependencies cached from previous step)
 RUN --mount=type=cache,target=/root/.cache \
  . /isso/bin/activate \
- && python3 setup.py develop --no-deps
+ && pip install -e . --no-deps
 
 
 # =====================

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG PY_VERSION=3.10
 # First stage: Build Javascript client parts using NodeJS
 # =======================================================
 
-FROM node:current-alpine AS isso-js
+FROM docker.io/node:current-alpine AS isso-js
 WORKDIR /src/
 
 # make is not installed by default on alpine
@@ -33,7 +33,7 @@ RUN make js
 # ==================================================
 
 # Copy needed files
-FROM python:${PY_VERSION}-alpine AS isso-builder
+FROM docker.io/python:${PY_VERSION}-alpine AS isso-builder
 WORKDIR /isso/
 
 # Set up virtualenv
@@ -77,7 +77,7 @@ RUN --mount=type=cache,target=/root/.cache \
 # Third stage: Run Isso
 # =====================
 
-FROM python:${PY_VERSION}-alpine AS isso
+FROM docker.io/python:${PY_VERSION}-alpine AS isso
 WORKDIR /isso/
 COPY --from=isso-builder /isso/ .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Isso production Dockerfile
 
-ARG PY_VERSION=3.10
+ARG PY_VERSION=3.12
 
 # =======================================================
 # First stage: Build Javascript client parts using NodeJS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Isso production Dockerfile
 
+ARG PY_VERSION=3.10
+
+# =======================================================
 # First stage: Build Javascript client parts using NodeJS
+# =======================================================
 
 FROM node:current-alpine AS isso-js
 WORKDIR /src/
@@ -23,10 +27,13 @@ COPY ["isso/js/", "./isso/js/"]
 # Run webpack to generate minified Javascript
 RUN make js
 
+
+# ==================================================
 # Second stage: Create production-ready Isso package
+# ==================================================
 
 # Copy needed files
-FROM python:3.10-alpine AS isso-builder
+FROM python:${PY_VERSION}-alpine AS isso-builder
 WORKDIR /isso/
 
 # Set up virtualenv
@@ -66,8 +73,11 @@ RUN --mount=type=cache,target=/root/.cache \
  && python3 setup.py develop --no-deps
 
 
+# =====================
 # Third stage: Run Isso
-FROM python:3.10-alpine AS isso
+# =====================
+
+FROM python:${PY_VERSION}-alpine AS isso
 WORKDIR /isso/
 COPY --from=isso-builder /isso/ .
 

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ docker-release-push:
 	docker push $(ISSO_DOCKER_REGISTRY)/$(ISSO_RELEASE_IMAGE)
 
 docker-testbed:
-	docker build -f docker/Dockerfile-js-testbed -t $(TESTBED_IMAGE) .
+	DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile-js-testbed -t $(TESTBED_IMAGE) .
 
 # For maintainers only:
 docker-testbed-push:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-# https://docs.docker.com/compose/compose-file/compose-file-v3/
-version: "3.9"
-
 services:
 
   # Isso server should always reflect production image

--- a/docs/docs/contributing/documentation.rst
+++ b/docs/docs/contributing/documentation.rst
@@ -50,7 +50,7 @@ Install via pip:
 
 .. code-block:: console
 
-   $ virtualenv .venv && $ source .venv/bin/activate
+   $ virtualenv --download .venv && $ source .venv/bin/activate
    (.venv) $ pip install sphinx
    (.venv) $ sphinx-build --version
    ~> sphinx-build 4.5.0
@@ -157,7 +157,7 @@ Use ``.. code-block:: <language>`` and indent the code by one level:
    .. code-block:: console
 
         $ sudo apt install python3 python3-pip python3-virtualenv
-        $ virtualenv .venv
+        $ virtualenv --download .venv
         $ source .venv/bin/activate
         (.venv) $ python [cmd]
 

--- a/docs/docs/reference/installation.rst
+++ b/docs/docs/reference/installation.rst
@@ -82,7 +82,7 @@ Install from PyPi
 Requirements
 ^^^^^^^^^^^^
 
-- Python 3.8+ (+ devel headers)
+- Python 3.8+ (+ devel headers) and Virtualenv
 - SQLite 3.3.8 or later
 - a working C compiler
 
@@ -91,13 +91,13 @@ For Debian/Ubuntu just `copy and paste
 
 .. code-block:: console
 
-    $ sudo apt-get install python3-dev sqlite3 build-essential
+    $ sudo apt-get install python3-dev python3-virtualenv sqlite3 build-essential
 
 Similar for Fedora (and derivates):
 
 .. code-block:: console
 
-    $ sudo yum install python3-devel sqlite
+    $ sudo yum install python3-devel python3-virtualenv sqlite
     $ sudo yum groupinstall “Development Tools”
 
 Installation

--- a/docs/docs/reference/installation.rst
+++ b/docs/docs/reference/installation.rst
@@ -48,7 +48,7 @@ but not recommended):
 
 .. code-block:: console
 
-    $ virtualenv /opt/isso
+    $ virtualenv --download /opt/isso
     $ source /opt/isso/bin/activate
 
 .. note::
@@ -216,7 +216,7 @@ To create a virtual environment (recommended), run:
 
 .. code-block:: console
 
-    $ virtualenv .venv
+    $ virtualenv --download .venv
     $ source .venv/bin/activate
 
 Install JavaScript modules using ``npm``:
@@ -235,7 +235,7 @@ Install Isso and its dependencies:
 
 .. code-block:: console
 
-    (.venv) $ python setup.py develop  # or `pip install -e .`
+    (.venv) $ pip install -e .  # -e = "editable" installation for development
     (.venv) $ isso -c /path/to/isso.cfg run
 
 .. _init-scripts:

--- a/docs/docs/technical-docs/testing-client.rst
+++ b/docs/docs/technical-docs/testing-client.rst
@@ -87,7 +87,7 @@ Start the server and ensure that the comment database is empty:
 .. code-block:: bash
 
    $ mv comments.db comments.db.bak
-   $ virtualenv .venv
+   $ virtualenv --download .venv
    $ source .venv/bin/activate
    (.venv) $ isso -c contrib/isso-dev.cfg run
 

--- a/docs/docs/technical-docs/testing.rst
+++ b/docs/docs/technical-docs/testing.rst
@@ -37,7 +37,7 @@ a development server available at ``localhost:8080``.
 
 .. code-block:: bash
 
-   $ virtualenv .venv
+   $ virtualenv --download .venv
    $ source .venv/bin/activate
    (.venv) $ isso -c contrib/isso-dev.cfg run
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     install_requires=[
         'itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',
-        'werkzeug>=1.0', 'bleach'],
+        'werkzeug>=1.0', 'bleach', 'setuptools'],
     tests_require=['pytest', 'pytest-cov'],
     extras_require={
         'doc': ['Sphinx'],

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     install_requires=[
         'itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [ ] (If adding features:) I have added tests to cover my changes
- [x] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
Compatibility for Python 3.12 and a few stray nits

* Mentions needed `virtualenv` package in docs, make pip and virtualenv related commands more consistent
* Require `setuptools` in `setup.py` (mostly because of `pkg_resources`)
* docker: Use buildkit in another instance of the `Makefile`, remove version from `compose` file, improve `Dockerfile` formatting
* Mark Python 3.12 support in `setup.py` and use it in `Dockerfile`, GitHub Actions

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->

Python 3.12 changes: [What's new](https://docs.python.org/3/whatsnew/3.12.html)

> [gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install `setuptools` in virtual environments created with `venv`. This means that `distutils`, `setuptools`, `pkg_resources`, and `easy_install` will no longer available by default; to access these run `pip install setuptools` in the activated virtual environment.

- We were using `python -m venv` and `virtualenv` interchangeably in the docs
- In Python 3.12, `python -m venv` seemingly no longer pulls in `pip` and `setuptools`, so switch to `virtualenv` instead
- `python setup.py develop` is now even more heavily discouraged