### PR TITLE
ext: notifications: Add link logging for management of new comments in Stdout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Bugfixes & Improvements
 - Handle deleted comments in Disqus migration (`#994`_, pkvach)
 - Fix total comments count calculation (`#997`_, pkvach)
 - Fix newline character handling in data-isso-* i18n strings (`#992`_, pkvach)
+- Add link logging for management of new comments in Stdout (`#1016`_, pkvach)
 
 .. _#951: https://github.com/posativ/isso/pull/951
 .. _#967: https://github.com/posativ/isso/pull/967
@@ -42,6 +43,7 @@ Bugfixes & Improvements
 .. _#994: https://github.com/isso-comments/isso/pull/994
 .. _#997: https://github.com/isso-comments/isso/pull/997
 .. _#992: https://github.com/isso-comments/isso/pull/992
+.. _#1016: https://github.com/isso-comments/isso/pull/1016
 
 0.13.1.dev0 (2023-02-05)
 ------------------------

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -110,7 +110,7 @@ class Isso(object):
         smtp_backend = False
         for backend in conf.getlist("general", "notify"):
             if backend == "stdout":
-                subscribers.append(Stdout(None))
+                subscribers.append(Stdout(self))
             elif backend in ("smtp", "SMTP"):
                 smtp_backend = True
             else:


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
When the server is configured with `general.notify = stdout` and `moderation.enabled = true`, new comment activation links are not added to Stdout.
I modified the Stdout class to log a direct link to a new comment, as well as links to delete or activate the comment.

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
Fixes https://github.com/isso-comments/isso/issues/138

