### PR TITLE
Change logging to include datetime and loglevel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,7 @@ Bugfixes & Improvements
 - Fix total comments count calculation (`#997`_, pkvach)
 - Fix newline character handling in data-isso-* i18n strings (`#992`_, pkvach)
 - Add link logging for management of new comments in Stdout (`#1016`_, pkvach)
+- Change logging to include datetime and loglevel (`#1023`_, ix5)
 
 .. _#951: https://github.com/posativ/isso/pull/951
 .. _#967: https://github.com/posativ/isso/pull/967
@@ -52,6 +53,7 @@ Bugfixes & Improvements
 .. _#997: https://github.com/isso-comments/isso/pull/997
 .. _#992: https://github.com/isso-comments/isso/pull/992
 .. _#1016: https://github.com/isso-comments/isso/pull/1016
+.. _#1023: https://github.com/isso-comments/isso/pull/1023
 
 0.13.1.dev0 (2023-02-05)
 ------------------------

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -69,10 +69,11 @@ from isso.views import comments
 
 from isso.ext.notifications import Stdout, SMTP
 
+LOG_FORMAT = "%(asctime)s:%(levelname)s: %(message)s"
 logging.getLogger('werkzeug').setLevel(logging.WARN)
 logging.basicConfig(
     level=logging.INFO,
-    format="%(asctime)s %(levelname)s: %(message)s")
+    format=LOG_FORMAT)
 
 logger = logging.getLogger("isso")
 
@@ -280,6 +281,7 @@ def main():
 
     if conf.get("general", "log-file"):
         handler = logging.FileHandler(conf.get("general", "log-file"))
+        handler.setFormatter(logging.Formatter(LOG_FORMAT))
 
         logger.addHandler(handler)
         logging.getLogger("werkzeug").addHandler(handler)


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [ ] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
This change propagates the log format formerly only for werkzeug to all isso logs.

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
Having date and time information as well as the loglevel should satisfy most users instead of the more complicated solution in https://github.com/isso-comments/isso/pull/976