### PR TITLE
Invert screenshot for dark color theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ details and [documentation](https://isso-comments.de/docs/).
 ## Screenshot
 
 <picture>
- <source media="(prefers-color-scheme: dark)" srcset="https://github.com/isso-comments/isso/assets/6305520/741b312e-798c-412b-918d-39d96deb4a5d">
+ <source media="(prefers-color-scheme: dark)" srcset="https://github.com/isso-comments/isso/assets/6305520/39892cd1-2930-4b73-ba8b-88ec6d1da4ce">
  <img alt="Isso in Action" src="https://user-images.githubusercontent.com/10212877/167268553-3f30b448-25ff-4850-afef-df2f2e599c93.png">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ details and [documentation](https://isso-comments.de/docs/).
 
 ## Screenshot
 
-![Isso in Action](https://user-images.githubusercontent.com/10212877/167268553-3f30b448-25ff-4850-afef-df2f2e599c93.png)
+<picture>
+ <source media="(prefers-color-scheme: dark)" srcset="https://github.com/isso-comments/isso/assets/6305520/741b312e-798c-412b-918d-39d96deb4a5d">
+ <img alt="Isso in Action" src="https://user-images.githubusercontent.com/10212877/167268553-3f30b448-25ff-4850-afef-df2f2e599c93.png">
+</picture>
 
 ## Getting started
 


### PR DESCRIPTION
## Checklist
- [x] Did none of the above
## What changes does this Pull Request introduce?
This inverts the screenshots on the README of this repo.

## Why is this necessary?
My eyes, bug prevention

For comparison see [`patch-1`](https://github.com/oberrich/isso/tree/patch-1?tab=readme-ov-file#screenshot) vs. [`master`](https://github.com/oberrich/isso?tab=readme-ov-file#screenshot). You may want to change the URL of the dark mode logo so it doesn't go away when I delete the `patch-1` tag.