### PR TITLE
isso: config: Add support for environment variables in config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ New Features
 - Add support for comment search by Thread URL in admin interface (`#1020`_, pkvach)
 - Add sorting option for comments (`#1005`_, pkvach)
 - admin: Add log out button (`#870`_, bbaovanc)
+- Add support for environment variables in config (`#1037`_, pkvach)
 
 .. _#870: https://github.com/posativ/isso/pull/870
 .. _#966: https://github.com/posativ/isso/pull/966
@@ -22,6 +23,7 @@ New Features
 .. _#1001: https://github.com/isso-comments/isso/pull/1001
 .. _#1020: https://github.com/isso-comments/isso/pull/1020
 .. _#1005: https://github.com/isso-comments/isso/pull/1005
+.. _#1037: https://github.com/isso-comments/isso/pull/1037
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^

--- a/docs/docs/reference/server-config.rst
+++ b/docs/docs/reference/server-config.rst
@@ -572,3 +572,24 @@ Booleans
    ``on``/``off`` etc.
 
 .. _getboolean: https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.getboolean
+
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^
+.. versionadded:: 0.13.1
+
+You can use environment variables in the configuration file. This is useful for keeping sensitive information, such as passwords, out of the configuration file itself. Environment variables are referenced using the ``$VAR_NAME`` or ``${VAR_NAME}`` syntax.
+
+Example:
+
+.. code-block:: ini
+   :caption: ``isso.cfg``
+
+    [general]
+    dbpath = /var/lib/isso/comments.db
+    host = https://example.tld/
+
+    [smtp]
+    username = $SMTP_USERNAME
+    password = ${SMTP_PASSWORD}
+
+In this example, the values for ``username`` and ``password`` will be taken from the environment variables ``SMTP_USERNAME`` and ``SMTP_PASSWORD``, respectively.

--- a/isso/config.py
+++ b/isso/config.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+import os
 import pkg_resources
 import re
 
@@ -82,6 +83,7 @@ class IssoParser(ConfigParser):
         * Parse human-readable timedelta such as "15m" as "15 minutes"
         * Handle indented lines as "lists"
         * Disable string interpolation ('%s') for values
+        * Support environment variable substitution
     """
 
     def __init__(self, *args, **kwargs):
@@ -94,6 +96,10 @@ class IssoParser(ConfigParser):
         """
         return super(IssoParser, self).__init__(
             allow_no_value=True, interpolation=None, *args, **kwargs)
+
+    def get(self, section, key, **kwargs):
+        value = super(IssoParser, self).get(section, key, **kwargs)
+        return os.path.expandvars(value)
 
     def getint(self, section, key):
         try:

--- a/isso/tests/test_config.py
+++ b/isso/tests/test_config.py
@@ -2,6 +2,7 @@
 
 import unittest
 import io
+import os
 
 from isso import config
 
@@ -34,3 +35,51 @@ class TestConfig(unittest.TestCase):
         # Section.get() should function the same way as plain IssoParser
         foosection = parser.section("foo")
         self.assertEqual(foosection.get("password"), '%s%%foo')
+
+    def test_parser_with_environment_variables(self):
+
+        parser = config.IssoParser()
+        parser.read_file(io.StringIO("""
+            [foo]
+            bar = $TEST_ENV_VAR
+            baz = ${TEST_ENV_VAR2}
+        """))
+
+        # Set environment variables
+        os.environ['TEST_ENV_VAR'] = 'test_value'
+        os.environ['TEST_ENV_VAR2'] = 'another_test_value'
+
+        # Test environment variable expansion
+        self.assertEqual(parser.get("foo", "bar"), 'test_value')
+        self.assertEqual(parser.get("foo", "baz"), 'another_test_value')
+
+        # Test Section.get() with environment variables
+        foosection = parser.section("foo")
+        self.assertEqual(foosection.get("bar"), 'test_value')
+        self.assertEqual(foosection.get("baz"), 'another_test_value')
+
+        # Clean up environment variables
+        del os.environ['TEST_ENV_VAR']
+        del os.environ['TEST_ENV_VAR2']
+
+    def test_parser_with_missing_environment_variables(self):
+
+        parser = config.IssoParser()
+        parser.read_file(io.StringIO("""
+            [foo]
+            bar = $MISSING_ENV_VAR
+        """))
+
+        self.assertEqual(parser.get("foo", "bar"), '$MISSING_ENV_VAR')
+
+    def test_parser_with_special_characters_in_environment_variables(self):
+
+        os.environ['SPECIAL_ENV_VAR'] = 'value_with_$pecial_characters'
+        parser = config.IssoParser()
+        parser.read_file(io.StringIO("""
+            [foo]
+            bar = $SPECIAL_ENV_VAR
+        """))
+
+        self.assertEqual(parser.get("foo", "bar"), 'value_with_$pecial_characters')
+        del os.environ['SPECIAL_ENV_VAR']


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- [x] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
Adds support for using environment variables in the Isso configuration file (isso.cfg). Environment variables can be referenced using the `$VAR_NAME` or `${VAR_NAME}` syntax.
This allows users to keep sensitive information, such as passwords, out of the configuration file itself by referencing environment variables.

- Updated `IssoParser` to support environment variable substitution.
- Enhanced documentation to include details on using environment variables in the configuration file.
- Added unit tests to verify the functionality of environment variable substitution in `IssoParser`.

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
Closes https://github.com/isso-comments/isso/issues/397
