### PR TITLE
Fix: now applying the same verifications when creating or editing comments

### DIFF
--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -391,6 +391,22 @@ class TestComments(unittest.TestCase):
         self.assertEqual(rv['website'], 'http://example.com/')
         self.assertIn('modified', rv)
 
+    def testUpdateForbidden(self):
+
+        self.post('/new?uri=test', data=json.dumps({'text': 'Hello world!'}))
+
+        resp = self.put('/id/1', data=json.dumps({}))
+        self.assertEqual(resp.status, '400 BAD REQUEST')
+        self.assertIn('text is missing', resp.text)
+
+        resp = self.put('/id/1', data=json.dumps({'text': ''}))
+        self.assertEqual(resp.status, '400 BAD REQUEST')
+        self.assertIn('text is too short', resp.text)
+
+        resp = self.put('/id/1', data=json.dumps({'text': 'Hello again!', 'website': 'name@example.com'}))
+        self.assertEqual(resp.status, '400 BAD REQUEST')
+        self.assertIn('Website not Django-conform', resp.text)
+
     def testDelete(self):
 
         self.post('/new?uri=%2Fpath%2F',

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -539,11 +539,12 @@ class API(object):
 
         data = request.json
 
-        if data.get("text") is None or len(data["text"]) < 3:
-            raise BadRequest("no text given")
-
         for key in set(data.keys()) - set(["text", "author", "website"]):
             data.pop(key)
+
+        valid, reason = API.verify(data)
+        if not valid:
+            return BadRequest(reason)
 
         data['modified'] = time.time()
 


### PR DESCRIPTION
## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- [-] (If docs changes needed:) I have updated the **documentation** accordingly.
- [-] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**

## What changes does this Pull Request introduce?
The same `API.verify()` method is called when creating a new comment or editing existing ones.
Previously, `API.verify()` was only called during comment creation.

## Why is this necessary?
In order to face spammers, I use a custom `API.verify()` method on my isso instance to forbids URLs in comments
( while waiting for some other spam-control mechanism to be implemented in isso maybe on day, _cf._ https://github.com/isso-comments/isso/issues/941 )

On my instance, I have seen spammers creating empty comments and then editing them to insert URLs.

This PR ensures that the same rules defined in `API.verify()` are applied during all the "life cycle" of a comment.