### PR TITLE
.github: Update actions to upload-artifact@v4

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Archive and upload updated screenshots & hashes
         if: ${{ steps.compare-screenshots.outcome == 'failure' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: updated-screenshots-and-hashes
           path: isso/js/tests/screenshots/reference/

--- a/.github/workflows/javascript-client.yml
+++ b/.github/workflows/javascript-client.yml
@@ -70,7 +70,7 @@ jobs:
       run: make js
 
     - name: Archive and upload generated minified client files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: client-js-files
         path: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -55,7 +55,7 @@ jobs:
       run: pip install dist/${{ steps.generate-package.outputs.package_file }}
 
     - name: Archive and upload generated package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }}-python-${{ matrix.python-version }}-${{ steps.generate-package.outputs.package_file }}
         path: dist/${{ steps.generate-package.outputs.package_file }}


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [ ] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [ ] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
Update the GitHub actions workflows to use the v4 variant of `actions/upload-artifact`.

## Why is this necessary?

upload-artifact@v3 has been sunset and will result in CI failures.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
