### PR TITLE
js: admin: update comment counts dynamically after moderation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,12 @@ New Features
 - Add option to show/hide website field in comment form (`#1111`_, pkvach)
 - Restrict maximum length of fields in ``comments.API.verify`` (`#1117`_, NicolaiSoeborg)
 - Add no-cache headers to fix stale comment display (`#1110`_, pkvach)
+- Update comment counts in the admin interface dynamically after moderation. (`#1113`_, pkvach)
 
 .. _#1111: https://github.com/isso-comments/isso/pull/1111
 .. _#1117: https://github.com/isso-comments/isso/pull/1117
 .. _#1110: https://github.com/isso-comments/isso/pull/1110
+.. _#1113: https://github.com/isso-comments/isso/pull/1113
 
 0.14.0 (2026-03-26)
 --------------------

--- a/isso/js/admin.js
+++ b/isso/js/admin.js
@@ -24,12 +24,32 @@ function fade(element) {
         op -= op * 0.1;
     }, 10);
 }
+const modeCountIds = {1: 'count-mode-1', 2: 'count-mode-2', 4: 'count-mode-4'};
+
+function setCountBadge(modeId, count) {
+    const el = document.getElementById(modeId);
+    if (!el) return;
+    const countEl = el.querySelector('.count');
+    if (!countEl) return;
+    countEl.textContent = count;
+}
+
 function moderate(com_id, hash, action, isso_host_script) {
-  ajax({method: "POST",
-        url: isso_host_script + "/id/" + com_id + "/" + action + "/" + hash,
-        success: function(){
-            fade(document.getElementById("isso-" + com_id));
-        }});
+    ajax({method: "POST",
+          url: isso_host_script + "/id/" + com_id + "/" + action + "/" + hash,
+          success: function(responseText){
+              fade(document.getElementById("isso-" + com_id));
+              try {
+                  const data = JSON.parse(responseText);
+                  if (data.counts) {
+                      for (const [mode, modeId] of Object.entries(modeCountIds)) {
+                          setCountBadge(modeId, data.counts[mode] || 0);
+                      }
+                  }
+              } catch (e) {
+                  console.error("Failed to parse moderate response:", e);
+              }
+          }});
 }
 function edit(com_id, hash, author, email, website, comment, isso_host_script) {
   ajax({method: "POST",
@@ -133,4 +153,9 @@ function log_out() {
 function toggleTooltip(tooltipContainer) {
     const tooltipText = tooltipContainer.querySelector(".search-tooltip-text");
     tooltipText.classList.toggle("show");
+}
+
+// Guard needed: admin.js is served raw (not bundled), so module is undefined in browsers
+if (typeof module !== 'undefined') {
+    module.exports = { setCountBadge };
 }

--- a/isso/js/tests/unit/admin.test.js
+++ b/isso/js/tests/unit/admin.test.js
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* Keep the above exactly as-is!
+ * https://jestjs.io/docs/configuration#testenvironment-string
+ */
+
+const { setCountBadge } = require("admin");
+
+describe("setCountBadge", () => {
+    test("sets count to given value", () => {
+        document.body.innerHTML = `<span id="count-mode-1">Valid (<span class="count">3</span>)</span>`;
+        setCountBadge("count-mode-1", 7);
+        expect(document.getElementById("count-mode-1").querySelector('.count').textContent).toBe("7");
+    });
+
+    test("sets count to zero", () => {
+        document.body.innerHTML = `<span id="count-mode-2">Pending (<span class="count">5</span>)</span>`;
+        setCountBadge("count-mode-2", 0);
+        expect(document.getElementById("count-mode-2").querySelector('.count').textContent).toBe("0");
+    });
+
+    test("does nothing when count span is absent", () => {
+        document.body.innerHTML = `<span id="count-mode-2">Pending (3)</span>`;
+        expect(() => setCountBadge("count-mode-2", 5)).not.toThrow();
+        expect(document.getElementById("count-mode-2").textContent).toBe("Pending (3)");
+    });
+
+    test("does nothing for a nonexistent element", () => {
+        document.body.innerHTML = "";
+        expect(() => setCountBadge("count-mode-99", 1)).not.toThrow();
+    });
+});

--- a/isso/templates/admin.html
+++ b/isso/templates/admin.html
@@ -24,18 +24,18 @@
       <div class="filters">
         <div class="mode">
           <a href="?mode=1&page={{page}}&order_by={{order_by}}">
-            <span class="label label-valid {% if mode == 1 %}active{% endif %}">
-              Valid ({{counts.get(1, 0)}})
+            <span id="count-mode-1" class="label label-valid {% if mode == 1 %}active{% endif %}">
+              Valid (<span class="count">{{counts.get(1, 0)}}</span>)
             </span>
           </a>
           <a href="?mode=2&page={{page}}&order_by={{order_by}}">
-            <span class="label label-pending {% if mode == 2 %}active{% endif %}">
-              Pending ({{counts.get(2, 0)}})
+            <span id="count-mode-2" class="label label-pending {% if mode == 2 %}active{% endif %}">
+              Pending (<span class="count">{{counts.get(2, 0)}}</span>)
             </span>
           </a>
           <a href="?mode=4&page={{page}}&order_by={{order_by}}">
-            <span class="label label-staled {% if mode == 4 %}active{% endif %}">
-              Staled ({{counts.get(4, 0)}})
+            <span id="count-mode-4" class="label label-staled {% if mode == 4 %}active{% endif %}">
+              Staled (<span class="count">{{counts.get(4, 0)}}</span>)
             </span>
           </a>
         </div>

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -837,12 +837,13 @@ class TestModeratedComments(unittest.TestCase):
         action = "activate"
         rv_activated = self.client.post("/id/%d/%s/%s" % (id_, action, signed))
         self.assertEqual(rv_activated.status_code, 200)
-        self.assertEqual(rv_activated.data, b"Comment has been activated")
+        # JSON serializes integer keys as strings; 1 comment now in mode=1
+        self.assertEqual(loads(rv_activated.data)["counts"], {"1": 1})
 
         # Activating should be idempotent
         rv_activated = self.client.post("/id/%d/%s/%s" % (id_, action, signed))
         self.assertEqual(rv_activated.status_code, 200)
-        self.assertEqual(rv_activated.data, b"Already activated")
+        self.assertEqual(loads(rv_activated.data)["counts"], {"1": 1})
 
         # Comment should have mode=1 (activated)
         self.assertEqual(self.app.db.comments.get(id_)["mode"], 1)
@@ -863,7 +864,8 @@ class TestModeratedComments(unittest.TestCase):
         action = "delete"
         rv_deleted = self.client.post("/id/%d/%s/%s" % (id_, action, signed))
         self.assertEqual(rv_deleted.status_code, 200)
-        self.assertEqual(rv_deleted.data, b"Comment has been deleted")
+        # comment fully deleted (no references), so all mode counts are empty
+        self.assertEqual(loads(rv_deleted.data)["counts"], {})
 
         # Comment should no longer exist
         self.assertEqual(self.app.db.comments.get(id_), None)

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -784,6 +784,9 @@ class API(object):
     @apiParam {String} key
         The moderation key to authenticate the moderation.
 
+    @apiSuccess {Object} counts
+        Number of comments per mode (`1`: accepted, `2`: in moderation queue, `4`: deleted, but referenced), after the moderation action was applied. A mode absent from `counts` has zero comments. Note that although mode is a `Number`, JSON object keys are always strings, so the mode keys in this object are strings (e.g. `"1"`, not `1`).
+
     @apiExample {curl} delete comment with id 13:
         curl -X POST 'https://comments.example.com/id/13/delete/MTM.CjL6Fg.REIdVXa-whJS_x8ojQL4RrXnuF4'
 
@@ -802,11 +805,11 @@ class API(object):
                     }
                 </script>
 
-    @apiSuccessExample Delete using POST:
-        Comment has been deleted
+    @apiSuccessExample {json} Delete using POST:
+        {"counts": {"1": 3, "4": 1}}
 
-    @apiSuccessExample Activate using POST:
-        Comment has been activated
+    @apiSuccessExample {json} Activate using POST:
+        {"counts": {"1": 4, "2": 1}}
     """
 
     def moderate(self, environ, request, id, action, key):
@@ -843,11 +846,11 @@ class API(object):
 
         if action == "activate":
             if item["mode"] == 1:
-                return Response("Already activated", 200)
+                return JSON({"counts": self.comments.count_modes()}, 200)
             with self.isso.lock:
                 self.comments.activate(id)
             self.signal("comments.activate", thread, item)
-            return Response("Comment has been activated", 200)
+            return JSON({"counts": self.comments.count_modes()}, 200)
         elif action == "edit":
             data = request.json
 
@@ -876,7 +879,7 @@ class API(object):
                 self.comments.delete(id)
             self.cache.delete("hash", (item["email"] or item["remote_addr"]).encode("utf-8"))
             self.signal("comments.delete", id)
-            return Response("Comment has been deleted", 200)
+            return JSON({"counts": self.comments.count_modes()}, 200)
 
     """
     @api {get} / Get comments


### PR DESCRIPTION
<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- [ ] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

> [!NOTE]
> I've created a separate PR for fixing issue with E2E tests: https://github.com/isso-comments/isso/pull/1114

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
Update the "Valid", "Pending", and "Staled" count badges in the admin interface immediately after a comment is activated or deleted. This eliminates the need for a manual page reload.

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
Related #501