### PR TITLE
docker: pin Jest packages to 29.7.0 in testbed

### DIFF
--- a/docker/Dockerfile-js-testbed
+++ b/docker/Dockerfile-js-testbed
@@ -18,7 +18,7 @@ RUN npm install puppeteer
 # Skip downloading headless chromium again for future steps
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
-RUN npm install --no-save jest jest-puppeteer jest-environment-jsdom
+RUN npm install --no-save jest@^29.7.0 jest-puppeteer jest-environment-jsdom@^29.7.0
 
 # Need to set $CI so that jest-puppeteer applies sensible launch params for
 # running headless chromium. Otherwise, chromium will fail with a "missing


### PR DESCRIPTION

<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
Prevents an error during integration tests caused by a mismatch between Jest 30+ and older jest-puppeteer.

jest@30 was released and became latest on npm, breaking integration tests with:
```
  TypeError: this._moduleMocker.clearMocksOnScope is not a function
```
This aligns the testbed image with the versions specified in package.json.

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
Example of the error in a CI job: https://github.com/isso-comments/isso/actions/runs/26530340281/job/78145011881?pr=1113#step:9:20 
