### PR TITLE
Harden `API.verify`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,10 @@ New Features
 ^^^^^^^^^^^^
 
 - Add option to show/hide website field in comment form (`#1111`_, pkvach)
+- Restrict maximum length of fields in ``comments.API.verify`` (`#1117`_, NicolaiSoeborg)
 
 .. _#1111: https://github.com/isso-comments/isso/pull/1111
+.. _#1117: https://github.com/isso-comments/isso/pull/1117
 
 0.14.0 (2026-03-26)
 --------------------

--- a/docs/docs/technical-docs/server.rst
+++ b/docs/docs/technical-docs/server.rst
@@ -13,6 +13,19 @@ Isso uses some of the following dependencies:
 - `mistune <https://mistune.lepture.com/>`_ – a fast yet powerful Python Markdown parser
 - `html5lib <https://github.com/html5lib/html5lib-python>`_ – HTML(5) parser and sanitizer
 
+Security
+--------
+
+- **HTML sanitization:** Isso sanitizes the HTML generated from comment
+  Markdown with ``bleach``. The default renderer (Mistune) also escapes raw
+  HTML in comments.
+
+- **Signed cookies:** Isso uses ``itsdangerous`` to sign the cookies used
+  for administrator sessions and comment editing.
+
+- **Field length limits:** Each submitted comment field is limited to 65535
+  characters. Some fields like ``email`` is limited to `254 characters <http://tools.ietf.org/html/rfc5321#section-4.5.3>`__.
+
 .. attention::
 
    This section of the Isso documentation is incomplete. Please help by expanding it.

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -154,6 +154,11 @@ class TestComments(unittest.TestCase):
         for key in ("author", "website", "email"):
             self.assertFalse(verify({"text": True, key: 3.14}))
 
+        # value too long
+        self.assertTrue(verify({"text": "a" * 65535}))
+        self.assertFalse(verify({"text": "a" * 65536}))
+        self.assertFalse(verify({"text": "a", "random": "a" * 65536}))
+
         # text too short and/or blank
         for text in ("", "\n\n\n"):
             self.assertFalse(verify({"text": text}))

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -233,11 +233,12 @@ class API(object):
             if not isinstance(comment.get(key), (str, type(None))):
                 return False, "%s must be a string or null" % key
 
+        for key, value in comment.items():
+            if value and len(str(value)) > 65535:
+                return False, f"{key} is too long (maximum length: 65535)"
+
         if len(comment["text"].rstrip()) < 3:
             return False, "text is too short (minimum length: 3)"
-
-        if len(comment["text"]) > 65535:
-            return False, "text is too long (maximum length: 65535)"
 
         if len(comment.get("email") or "") > 254:
             return False, "http://tools.ietf.org/html/rfc5321#section-4.5.3"


### PR DESCRIPTION
No key should be larger than 2**16. Currently I believe it is possible to "spam" the "Author" field with very large keys

<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->

## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- [x] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
Maximum field size for comments (new/edit/etc) is 2**16

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
I was looking though the code and saw that "author" field wasn't covered by the current max size check. While the current code is a bit redundant I think that is best to cover all current and future cases.