### PR TITLE
Refactor comment edit cookie handling

### DIFF
--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -757,6 +757,19 @@ class TestModeratedComments(unittest.TestCase):
         self.app.db.comments.activate(1)
         self.assertEqual(self.client.get("/?uri=test").status_code, 200)
 
+    def testViewRejectsCookieIssuedForOtherComment(self):
+        """A cookie for one's own comment must not unlock a pending one."""
+        bob = JSONClient(self.app, Response)
+        bob.post("/new?uri=test", data=json.dumps({"text": "Bob's pending comment"}))
+
+        mallory = JSONClient(self.app, Response)
+        mallory.post("/new?uri=test", data=json.dumps({"text": "Mallory's comment"}))
+
+        cookie = mallory.get_cookie("2", domain="localhost").value
+        mallory.set_cookie("1", cookie, domain="localhost")
+
+        self.assertEqual(mallory.get("/id/1?plain=1").status_code, 403)
+
     def testModerateComment(self):
         id_ = 1
         signed = self.app.sign(id_)

--- a/isso/tests/test_comments.py
+++ b/isso/tests/test_comments.py
@@ -404,6 +404,26 @@ class TestComments(unittest.TestCase):
         r = self.get("/id/1?plain=1")
         self.assertEqual(r.status_code, 403)
 
+    def testCookieOfWrongTypeIsRejected(self):
+        """The signer is shared with admin session, moderation and unsubscribe
+        tokens, so payloads of a foreign shape must be refused, not indexed."""
+        self.post("/new?uri=%2Fpath%2F", data=json.dumps({"text": "Lorem ipsum ..."}))
+
+        for payload in ({"logged": True}, 1, ["unsubscribe", "bob@example.org"], "nope", []):
+            value = self.app.sign(payload)
+            self.client.set_cookie("1", value, domain="localhost")
+
+            self.assertEqual(self.get("/id/1?plain=1").status_code, 403)
+            self.assertEqual(self.put("/id/1", data=json.dumps({"text": "Hijacked"})).status_code, 403)
+            self.assertEqual(self.delete("/id/1").status_code, 403)
+
+    def testEditCookieForMissingCommentIsRejected(self):
+        self.client.set_cookie("99", self.app.sign([99, "deadbeef"]), domain="localhost")
+
+        self.assertEqual(self.get("/id/99?plain=1").status_code, 404)
+        self.assertEqual(self.put("/id/99", data=json.dumps({"text": "Hijacked"})).status_code, 404)
+        self.assertEqual(self.delete("/id/99").status_code, 404)
+
     def testDeleteWithReference(self):
         client = JSONClient(self.app, Response)
         client.post("/new?uri=%2Fpath%2F", data=json.dumps({"text": "First"}))

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -221,6 +221,28 @@ class API(object):
         for view, (method, path) in self.VIEWS:
             isso.urls.add(Rule(path, methods=[method], endpoint=getattr(self, view)))
 
+    def unsign_edit_cookie(self, request, id):
+        """
+        Unsign the edit cookie for comment :param:`id` and return its payload.
+
+        Raises Forbidden unless the cookie is a valid, unexpired `[id, checksum]`
+        pair issued for this very comment. The signer is shared with the admin
+        session, unsubscribe and moderation tokens, so a payload of the wrong
+        shape has to be rejected rather than indexed into.
+        """
+        try:
+            rv = self.isso.unsign(request.cookies.get(str(id), ""))
+        except (SignatureExpired, BadSignature):
+            raise Forbidden
+
+        if not isinstance(rv, list) or len(rv) != 2:
+            raise Forbidden
+
+        if rv[0] != id:
+            raise Forbidden
+
+        return rv
+
     @classmethod
     def verify(cls, comment):
         if comment.get("text") is None:
@@ -489,13 +511,7 @@ class API(object):
         if rv is None:
             raise NotFound
 
-        try:
-            signed = self.isso.unsign(request.cookies.get(str(id), ""))
-        except (SignatureExpired, BadSignature):
-            raise Forbidden
-
-        if signed[0] != id:
-            raise Forbidden
+        self.unsign_edit_cookie(request, id)
 
         for key in set(rv.keys()) - API.FIELDS:
             rv.pop(key)
@@ -546,16 +562,14 @@ class API(object):
 
     @xhr
     def edit(self, environ, request, id):
-        try:
-            rv = self.isso.unsign(request.cookies.get(str(id), ""))
-        except (SignatureExpired, BadSignature):
-            raise Forbidden
+        rv = self.unsign_edit_cookie(request, id)
 
-        if rv[0] != id:
-            raise Forbidden
+        item = self.comments.get(id)
+        if item is None:
+            raise NotFound
 
         # verify checksum, mallory might skip cookie deletion when he deletes a comment
-        if rv[1] != sha1(self.comments.get(id)["text"]):
+        if rv[1] != sha1(item["text"]):
             raise Forbidden
 
         data = request.json
@@ -637,22 +651,16 @@ class API(object):
 
     @xhr
     def delete(self, environ, request, id):
-        try:
-            rv = self.isso.unsign(request.cookies.get(str(id), ""))
-        except (SignatureExpired, BadSignature):
-            raise Forbidden
-        else:
-            if rv[0] != id:
-                raise Forbidden
-
-            # verify checksum, mallory might skip cookie deletion when he deletes a comment
-            if rv[1] != sha1(self.comments.get(id)["text"]):
-                raise Forbidden
+        rv = self.unsign_edit_cookie(request, id)
 
         item = self.comments.get(id)
 
         if item is None:
             raise NotFound
+
+        # verify checksum, mallory might skip cookie deletion when he deletes a comment
+        if rv[1] != sha1(item["text"]):
+            raise Forbidden
 
         self.cache.delete("hash", (item["email"] or item["remote_addr"]).encode("utf-8"))
 

--- a/isso/views/comments.py
+++ b/isso/views/comments.py
@@ -490,8 +490,11 @@ class API(object):
             raise NotFound
 
         try:
-            self.isso.unsign(request.cookies.get(str(id), ""))
+            signed = self.isso.unsign(request.cookies.get(str(id), ""))
         except (SignatureExpired, BadSignature):
+            raise Forbidden
+
+        if signed[0] != id:
             raise Forbidden
 
         for key in set(rv.keys()) - API.FIELDS:


### PR DESCRIPTION
Also, make sure we check the cookie when retrieving unreviewed comments.