### PR TITLE
Add webhook notification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,12 @@ New Features
 - Add option to show/hide website field in comment form (`#1111`_, pkvach)
 - Restrict maximum length of fields in ``comments.API.verify`` (`#1117`_, NicolaiSoeborg)
 - Add no-cache headers to fix stale comment display (`#1110`_, pkvach)
+- Add webhook support for comment events (`#1123`_, p1slave)
 
 .. _#1111: https://github.com/isso-comments/isso/pull/1111
 .. _#1117: https://github.com/isso-comments/isso/pull/1117
 .. _#1110: https://github.com/isso-comments/isso/pull/1110
+.. _#1123: https://github.com/isso-comments/isso/pull/1123
 
 0.14.0 (2026-03-26)
 --------------------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -126,5 +126,8 @@ In chronological order:
 * Fabian Ritzmann @ritzmann
   * Add Mistune as new Markdown rendering engine
 
+* p1slave <p1slave@protonmail.com>
+  * Add webhook integration
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/docs/docs/reference/server-config.rst
+++ b/docs/docs/reference/server-config.rst
@@ -103,7 +103,36 @@ notify
         Send notifications via SMTP on new comments with activation (if
         moderated) and deletion links.
 
+    webhook
+        POST a JSON event to an HTTP endpoint for every saved comment.
+
     Default: ``stdout``
+
+Webhook
+-------
+
+Add ``webhook`` to ``general.notify`` to receive a ``comment.created`` event
+after each comment is saved, including pending comments. The payload contains
+the event, thread ID/URI/title, and comment ID, parent, timestamps, mode,
+text, author, and website; it excludes email address, IP address, and voting
+data.
+
+.. code-block:: ini
+
+    [general]
+    notify = webhook
+
+    [webhook]
+    url =
+        https://example.com/hooks/isso
+        https://example.net/hooks/isso
+    secret = a-long-random-secret
+    timeout = 10
+
+Requests are POSTed as JSON with ``X-Isso-Event: comment.created``. When
+``secret`` is set, ``X-Isso-Signature`` is ``sha256=`` followed by the
+lowercase hexadecimal HMAC-SHA256 of the raw request body. Each configured
+URL receives the same event.
 
 reply-notifications
     Allow users to request E-mail notifications for replies to their post.

--- a/isso/__init__.py
+++ b/isso/__init__.py
@@ -69,7 +69,7 @@ from isso.wsgi import origin, urlsplit
 from isso.utils import http, JSONRequest, JSONResponse, hash
 from isso.views import comments
 
-from isso.ext.notifications import Stdout, SMTP
+from isso.ext.notifications import Stdout, SMTP, Webhook
 
 LOG_FORMAT = "%(asctime)s:%(levelname)s: %(message)s"
 logging.getLogger("werkzeug").setLevel(logging.WARN)
@@ -111,6 +111,8 @@ class Isso(object):
                 subscribers.append(Stdout(self))
             elif backend in ("smtp", "SMTP"):
                 smtp_backend = True
+            elif backend == "webhook":
+                subscribers.append(Webhook(self))
             else:
                 logger.warning("unknown notification backend '%s'", backend)
         if smtp_backend or conf.getboolean("general", "reply-notifications"):

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -238,7 +238,9 @@ class Webhook(object):
         payload = {
             "event": "comment.created",
             "thread": {key: thread[key] for key in ("id", "uri", "title")},
-            "comment": {key: comment[key] for key in ("id", "parent", "created", "modified", "mode", "text", "author", "website")},
+            "comment": {
+                key: comment[key] for key in ("id", "parent", "created", "modified", "mode", "text", "author", "website")
+            },
         }
         start_new_thread(self.send, (payload,))
 

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -2,6 +2,8 @@
 
 import io
 import json
+import hashlib
+import hmac
 import smtplib
 import socket
 import time
@@ -9,7 +11,9 @@ import time
 from _thread import start_new_thread
 from email.message import EmailMessage
 from email.utils import formatdate
+from urllib.error import URLError
 from urllib.parse import quote
+from urllib.request import Request, urlopen
 
 import logging
 
@@ -213,6 +217,46 @@ class SMTP(object):
                 time.sleep(60)
             else:
                 break
+
+
+class Webhook(object):
+    def __init__(self, isso):
+        self.conf = isso.conf.section("webhook")
+        self.urls = list(self.conf.getiter("url"))
+        self.secret = self.conf.get("secret")
+        self.timeout = self.conf.getint("timeout")
+
+        if not self.urls:
+            logger.warning("webhook notifications are enabled without webhook URLs")
+
+    def __iter__(self):
+        yield "comments.new:after-save", self.notify_new
+
+    def notify_new(self, thread, comment):
+        if not self.urls:
+            return
+
+        payload = {
+            "event": "comment.created",
+            "thread": {key: thread[key] for key in ("id", "uri", "title")},
+            "comment": {key: comment[key] for key in ("id", "parent", "created", "modified", "mode", "text", "author", "website")},
+        }
+        start_new_thread(self.send, (payload,))
+
+    def send(self, payload):
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        headers = {"Content-Type": "application/json", "X-Isso-Event": payload["event"]}
+        if self.secret:
+            digest = hmac.new(self.secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+            headers["X-Isso-Signature"] = "sha256=" + digest
+
+        for url in self.urls:
+            request = Request(url, data=body, headers=headers, method="POST")
+            try:
+                with urlopen(request, timeout=self.timeout):
+                    pass
+            except URLError:
+                logger.exception("unable to deliver comment webhook to %s", url)
 
 
 class Stdout(object):

--- a/isso/ext/notifications.py
+++ b/isso/ext/notifications.py
@@ -11,7 +11,6 @@ import time
 from _thread import start_new_thread
 from email.message import EmailMessage
 from email.utils import formatdate
-from urllib.error import URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
@@ -255,7 +254,7 @@ class Webhook(object):
             try:
                 with urlopen(request, timeout=self.timeout):
                     pass
-            except URLError:
+            except Exception:
                 logger.exception("unable to deliver comment webhook to %s", url)
 
 

--- a/isso/isso.cfg
+++ b/isso/isso.cfg
@@ -168,21 +168,6 @@ from =
 timeout = 10
 
 
-[webhook]
-# Add `webhook` to general.notify to POST an event for each saved comment.
-# List one URL per indented line.
-url =
-	https://example.com/hooks/isso
-	https://example.net/hooks/isso
-
-# Optional HMAC-SHA256 secret. When set, the request includes an
-# X-Isso-Signature header in the form `sha256=<hex digest>`.
-secret =
-
-# Timeout in seconds for webhook delivery.
-timeout = 10
-
-
 [guard]
 # Enable basic spam protection features, e.g. rate-limit per IP address (/24
 # for IPv4, /48 for IPv6).

--- a/isso/isso.cfg
+++ b/isso/isso.cfg
@@ -41,6 +41,8 @@ max-age = 15m
 # smtp
 #     Send notifications via SMTP on new comments with activation (if
 #     moderated) and deletion links.
+# webhook
+#     POST a signed JSON event to an HTTP endpoint for every new comment.
 notify = stdout
 
 # Allow users to request E-mail notifications for replies to their post.
@@ -163,6 +165,21 @@ from =
 
 # specify a timeout in seconds for blocking operations like the
 # connection attempt.
+timeout = 10
+
+
+[webhook]
+# Add `webhook` to general.notify to POST an event for each saved comment.
+# List one URL per indented line.
+url =
+	https://example.com/hooks/isso
+	https://example.net/hooks/isso
+
+# Optional HMAC-SHA256 secret. When set, the request includes an
+# X-Isso-Signature header in the form `sha256=<hex digest>`.
+secret =
+
+# Timeout in seconds for webhook delivery.
 timeout = 10
 
 

--- a/isso/tests/test_notifications.py
+++ b/isso/tests/test_notifications.py
@@ -1,0 +1,102 @@
+# -*- encoding: utf-8 -*-
+
+import hashlib
+import hmac
+import json
+import unittest
+
+from isso import config
+from isso.ext import notifications
+
+
+class TestWebhook(unittest.TestCase):
+    def test_new_comment_posts_signed_payload(self):
+        webhook = notifications.Webhook(
+            type(
+                "Isso",
+                (),
+                {
+                    "conf": config.new(
+                        {
+                            "webhook": {
+                                "url": """
+                                    https://hooks.example.test/first
+                                    https://hooks.example.test/second
+                                """,
+                                "secret": "test-secret",
+                                "timeout": "5",
+                            }
+                        }
+                    )
+                },
+            )()
+        )
+        dispatched = []
+        requests = []
+
+        def fake_start_new_thread(function, args):
+            dispatched.append((function, args))
+
+        def fake_urlopen(request, timeout):
+            requests.append((request, timeout))
+
+            class Response(object):
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc_value, traceback):
+                    pass
+
+            return Response()
+
+        original_start_new_thread = notifications.start_new_thread
+        original_urlopen = notifications.urlopen
+        notifications.start_new_thread = fake_start_new_thread
+        notifications.urlopen = fake_urlopen
+        try:
+            webhook.notify_new(
+                {"id": 1, "uri": "/post", "title": "A post"},
+                {
+                    "id": 2,
+                    "parent": None,
+                    "created": 1.0,
+                    "modified": None,
+                    "mode": 1,
+                    "text": "Hello",
+                    "author": "Alice",
+                    "website": "https://example.test",
+                    "email": "alice@example.test",
+                    "remote_addr": "192.0.2.1",
+                    "voters": b"private",
+                },
+            )
+
+            self.assertEqual(len(dispatched), 1)
+            function, args = dispatched[0]
+            function(*args)
+        finally:
+            notifications.start_new_thread = original_start_new_thread
+            notifications.urlopen = original_urlopen
+
+        self.assertEqual(len(requests), 2)
+        request, timeout = requests[0]
+        body = request.data
+        payload = json.loads(body.decode("utf-8"))
+
+        self.assertEqual(
+            [request.full_url for request, timeout in requests],
+            ["https://hooks.example.test/first", "https://hooks.example.test/second"],
+        )
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(request.get_header("Content-type"), "application/json")
+        self.assertEqual(request.get_header("X-isso-event"), "comment.created")
+        self.assertEqual(
+            request.get_header("X-isso-signature"),
+            "sha256=" + hmac.new(b"test-secret", body, hashlib.sha256).hexdigest(),
+        )
+        self.assertEqual(timeout, 5)
+        self.assertEqual(payload["thread"], {"id": 1, "uri": "/post", "title": "A post"})
+        self.assertEqual(payload["comment"]["id"], 2)
+        self.assertNotIn("email", payload["comment"])
+        self.assertNotIn("remote_addr", payload["comment"])
+        self.assertNotIn("voters", payload["comment"])


### PR DESCRIPTION
Add webhook notification supporting multiple webhook URLs with SHA256-based signature.

<!-- Just like NASA going to the moon, it's always good to have a checklist when
creating changes.
The following items are listed to help you create a great Pull Request: -->
## Checklist
- [x] All new and existing **tests are passing**
- [x] (If adding features:) I have added tests to cover my changes
- [x] (If docs changes needed:) I have updated the **documentation** accordingly.
- [x] I have added an entry to `CHANGES.rst` because this is a user-facing change or an important bugfix
- [x] I have written **proper commit message(s)**
      <!-- Title ideally under 50 characters (at most 72), good explanations,
      affected part of Isso mentioned in title, e.g. "docs: css: Increase font-size on buttons"
      Further info: https://github.com/joelparkerhenderson/git-commit-message -->

## What changes does this Pull Request introduce?
<!-- Explain what this PR will do, how one can try out the changes -->
Add webhook notification configuration and implementation. The user needs to set up a separate web server with public access to test it. Whenever a new comment is added, your web server will receive a request from Isso. A telegram bot example will be provided soon. 

## Why is this necessary?
<!-- Link to existing bugs, post reproducible setups that demonstrate the
     issue/change -->
People want to receive notification in ways other than email and webhook provides a way to do it without integration with third party clients.
